### PR TITLE
Fix analytics field mismatch

### DIFF
--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -11,7 +11,7 @@ interface AnalyticsProps {
 }
 
 export function Analytics({ linkId, links, onSelectLink }: AnalyticsProps) {
-  const { data: analytics, isLoading } = useQuery({
+  const { data: analytics, isLoading } = useQuery<AnalyticsType | null>({
     queryKey: ['analytics', linkId],
     queryFn: async () => {
       if (!linkId) return null;
@@ -109,7 +109,7 @@ export function Analytics({ linkId, links, onSelectLink }: AnalyticsProps) {
                 <span className="text-sm font-medium text-blue-900">Total Clicks</span>
               </div>
               <div className="mt-2">
-                <span className="text-2xl font-bold text-blue-900">{analytics.click_count}</span>
+                <span className="text-2xl font-bold text-blue-900">{analytics.total_clicks}</span>
               </div>
             </div>
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -100,9 +100,14 @@ export type Link = {
 
 export type Analytics = {
   link_id: string;
-  click_count: number;
+  total_clicks: number;
+  clicks_today: number;
+  clicks_this_week: number;
+  clicks_this_month: number;
   recent_clicks: Array<{
+    id?: string;
     clicked_at: string;
     ip_address: string;
+    user_agent?: string;
   }>;
 };


### PR DESCRIPTION
## Summary
- fix naming mismatch between API and frontend analytics

## Testing
- `npm test`
- `PYTHONPATH=backend pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_688a65bc34088325bd5d2b0aa630cc3a